### PR TITLE
Ability to compile on Linux. Using gnu99 in place of c99

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,19 @@ SRC=	ce.c buffer.c editor.c syntax.c term.c utf8.c
 
 CFLAGS+=-Wall -Werror -Wstrict-prototypes -Wmissing-prototypes
 CFLAGS+=-Wmissing-declarations -Wshadow -Wpointer-arith -Wcast-qual
-CFLAGS+=-Wsign-compare -std=c99 -pedantic -ggdb
+
+OSNAME=$(shell uname -s | sed -e 's/[-_].*//g' | tr A-Z a-z)
+
+ifeq ($(OSNAME),linux)
+        CFLAGS+=-Wsign-compare -std=gnu99 -pedantic -ggdb -D _GNU_SOURCE
+else
+        CFLAGS+=-Wsign-compare -std=c99 -pedantic -ggdb
+endif
+
 CFLAGS+=-DPREFIX='"$(PREFIX)"' -fstack-protector-all
 
 OBJS=	$(SRC:%.c=$(OBJDIR)/%.o)
 
-OSNAME=$(shell uname -s | sed -e 's/[-_].*//g' | tr A-Z a-z)
 ifeq ("$(OSNAME)", "darwin")
 	OBJS+=$(OBJDIR)/macos.o
 	LDFLAGS+=-framework Foundation -framework Appkit


### PR DESCRIPTION
I was trying to compile it on Ubuntu 18.04. But, I was not able to do it. Due to _**c99**_ check _**getopt**_ functions were not found. So, I made a change to make it compatible for linux OS.