### PR TITLE
Added syntax hightlight for Java 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,22 +11,17 @@ SRC=	ce.c buffer.c editor.c syntax.c term.c utf8.c
 
 CFLAGS+=-Wall -Werror -Wstrict-prototypes -Wmissing-prototypes
 CFLAGS+=-Wmissing-declarations -Wshadow -Wpointer-arith -Wcast-qual
-
-OSNAME=$(shell uname -s | sed -e 's/[-_].*//g' | tr A-Z a-z)
-
-ifeq ($(OSNAME),linux)
-        CFLAGS+=-Wsign-compare -std=gnu99 -pedantic -ggdb -D _GNU_SOURCE
-else
-        CFLAGS+=-Wsign-compare -std=c99 -pedantic -ggdb
-endif
-
+CFLAGS+=-Wsign-compare -std=c99 -pedantic -ggdb
 CFLAGS+=-DPREFIX='"$(PREFIX)"' -fstack-protector-all
 
 OBJS=	$(SRC:%.c=$(OBJDIR)/%.o)
 
+OSNAME=$(shell uname -s | sed -e 's/[-_].*//g' | tr A-Z a-z)
 ifeq ("$(OSNAME)", "darwin")
 	OBJS+=$(OBJDIR)/macos.o
 	LDFLAGS+=-framework Foundation -framework Appkit
+else ifeq ("$(OSNAME)", "linux")
+        CFLAGS+=-D_GNU_SOURCE
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,19 @@ SRC=	ce.c buffer.c editor.c syntax.c term.c utf8.c
 
 CFLAGS+=-Wall -Werror -Wstrict-prototypes -Wmissing-prototypes
 CFLAGS+=-Wmissing-declarations -Wshadow -Wpointer-arith -Wcast-qual
-CFLAGS+=-Wsign-compare -std=c99 -pedantic -ggdb
+
+OSNAME=$(shell uname -s | sed -e 's/[-_].*//g' | tr A-Z a-z)
+
+ifeq ($(OSNAME),linux)
+        CFLAGS+=-Wsign-compare -std=gnu99 -pedantic -ggdb -D _GNU_SOURCE
+else
+        CFLAGS+=-Wsign-compare -std=c99 -pedantic -ggdb
+endif
+
 CFLAGS+=-DPREFIX='"$(PREFIX)"' -fstack-protector-all
 
 OBJS=	$(SRC:%.c=$(OBJDIR)/%.o)
 
-OSNAME=$(shell uname -s | sed -e 's/[-_].*//g' | tr A-Z a-z)
 ifeq ("$(OSNAME)", "darwin")
 	OBJS+=$(OBJDIR)/macos.o
 	LDFLAGS+=-framework Foundation -framework Appkit

--- a/ce.c
+++ b/ce.c
@@ -34,6 +34,7 @@ static struct {
 	{ ".patch",	CE_FILE_TYPE_DIFF },
 	{ ".js",	CE_FILE_TYPE_JS },
 	{ ".sh",	CE_FILE_TYPE_SHELL },
+	{ ".java",	CE_FILE_TYPE_JAVA },
 	{ NULL,		0 },
 };
 

--- a/ce.h
+++ b/ce.h
@@ -77,6 +77,7 @@
 #define CE_FILE_TYPE_DIFF		3
 #define CE_FILE_TYPE_JS			4
 #define CE_FILE_TYPE_SHELL		5
+#define CE_FILE_TYPE_JAVA               6
 
 /*
  * An operation that happened on a line.

--- a/ce.h
+++ b/ce.h
@@ -77,7 +77,7 @@
 #define CE_FILE_TYPE_DIFF		3
 #define CE_FILE_TYPE_JS			4
 #define CE_FILE_TYPE_SHELL		5
-#define CE_FILE_TYPE_JAVA               6
+#define CE_FILE_TYPE_JAVA		6
 
 #define CE_TAB_WIDTH_DEFAULT		8
 #define CE_TAB_EXPAND_DEFAULT		0

--- a/syntax.c
+++ b/syntax.c
@@ -153,20 +153,24 @@ static const char *py_special[] = {
 };
 
 static const char *java_kw[] = {
-        "do", "if", "for", "new", "try", "goto", "this", "else", "case", 
-	"null", "enum", "break", "throw", "catch", "final", "class", "super", "while",
-        "switch", "assert", "throws", "return", "static", "native", "default", "package", 
-	"extends", "finally", "abstract", "continue", "strictfp", "volatile", "transient", 
-	"interface", "implements", "instanceof", "synchronized", "default"
+	"do", "if", "for", "new", "try", "goto", "this", "else", 
+	"case", "null", "enum", "break", "throw", "catch", "final", 
+	"class", "super", "while", "switch", "assert", "throws", 
+	"return", "static", "native", "default", "package", "extends", 
+	"finally", "abstract", "continue", "strictfp", "volatile", 
+	"transient", "interface", "implements", "instanceof", "default",
+	"synchronized", NULL
 };
 
 static const char *java_types[] = {
-        "int", "short", "long", "double", "char", "byte", "float", "boolean", "String", 
-	"void", "Void", "Integer", "Short", "Long", "Double", "Float", "Character", "Byte"
+	"int", "short", "long", "double", "char", "byte", "float", 
+	"boolean", "String", "void", "Void", "Integer", "Short", 
+	"Long", "Double", "Float", "Character", "Byte", NULL
 };
 
 static const char *java_special[] = {
-	"import", "public", "private", "static", "protected", "class"
+	"import", "public", "private", "static", "protected", "class", 
+	NULL
 };
 
 
@@ -964,13 +968,13 @@ syntax_write(struct state *state, size_t len)
 static void
 syntax_highlight_java(struct state *state)
 {
+	if (syntax_highlight_c_comment(state) == 0)
+		return;
+
 	if (syntax_highlight_numeric(state) == 0)
 		return;
 
 	if (syntax_highlight_string(state) == 0)
-		return;
-
-	if (syntax_highlight_c_comment(state) == 0)
 		return;
 
         if (syntax_highlight_python_decorator(state) == 0)

--- a/syntax.c
+++ b/syntax.c
@@ -79,6 +79,8 @@ static void	syntax_highlight_python(struct state *);
 static int	syntax_highlight_python_decorator(struct state *);
 static int	syntax_highlight_python_multiline_string(struct state *);
 
+static void	syntax_highlight_java(struct state *);
+
 static int	syntax_highlight_string(struct state *);
 static int	syntax_highlight_numeric(struct state *);
 static void	syntax_highlight_format_string(struct state *);
@@ -150,6 +152,24 @@ static const char *py_types[] = {
 static const char *py_special[] = {
 	"import", "from", NULL
 };
+
+static const char *java_kw[] = {
+        "do", "if", "for", "new", "try", "goto", "this", "else", "case", 
+	"null", "enum", "break", "throw", "catch", "final", "class", "super", "while",
+        "switch", "assert", "throws", "return", "static", "native", "default", "package", 
+	"extends", "finally", "abstract", "continue", "strictfp", "volatile", "transient", 
+	"interface", "implements", "instanceof", "synchronized", "default"
+};
+
+static const char *java_types[] = {
+        "int", "short", "long", "double", "char", "byte", "float", "boolean", "String", 
+	"void", "Void", "Integer", "Short", "Long", "Double", "Float", "Character", "Byte"
+};
+
+static const char *java_special[] = {
+	"import", "public", "private", "static", "protected", "class"
+};
+
 
 static const char *js_kw[] = {
 	"break", "case", "catch", "continue", "debugger", "default",
@@ -260,6 +280,9 @@ ce_syntax_write(struct cebuf *buf, struct celine *line, size_t towrite)
 				break;
 			case CE_FILE_TYPE_SHELL:
 				syntax_highlight_shell(&syntax_state);
+				break;
+			case CE_FILE_TYPE_JAVA:
+				syntax_highlight_java(&syntax_state);
 				break;
 			default:
 				syntax_state_color_clear(&syntax_state);
@@ -937,3 +960,35 @@ syntax_write(struct state *state, size_t len)
 	ce_term_write(state->p, len);
 	state->off += len;
 }
+
+static void
+syntax_highlight_java(struct state *state)
+{
+	if (syntax_highlight_numeric(state) == 0)
+		return;
+
+	if (syntax_highlight_string(state) == 0)
+		return;
+
+	if (syntax_highlight_c_comment(state) == 0)
+		return;
+
+        if (syntax_highlight_python_decorator(state) == 0)
+	       return;
+
+	if (syntax_highlight_c_label(state) == 0)
+		return;
+
+	if (syntax_highlight_word(state, java_kw, TERM_COLOR_YELLOW) == 0)
+		return;
+
+	if (syntax_highlight_word(state, java_types, TERM_COLOR_CYAN) == 0)
+		return;
+
+	if (syntax_highlight_word(state, java_special, TERM_COLOR_MAGENTA) == 0)
+		return;
+
+	syntax_state_color_clear(state);
+	syntax_write(state, 1);
+}
+


### PR DESCRIPTION
In this pull request,

1. I have added -D_GNU_SOURCE in the Makefile
2. I have added syntax highlighting for  Java.

I am re-using **syntax_highlight_c_comment** and **syntax_highlight_c_label**  for comment highlighting and label highlighting. 
I am re-using **syntax_highlight_python_decorator** to highlight annotations in Java.

The names of these functions are specific to a language. But, we can use those functions for Java syntax highlighting.

I have not refactored or renamed anything, as this is your project.
